### PR TITLE
CI: stop failing preview deploy when Cloudflare accountId missing

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # This workflow is optional. If CLOUDFLARE_ACCOUNT_ID is not configured,
+    # skip the preview deploy instead of failing the entire Actions run history.
+    if: ${{ github.event.workflow_run.conclusion == 'success' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     runs-on: ubuntu-latest
     name: Deploy Preview to Cloudflare Pages
     steps:


### PR DESCRIPTION
Upload Preview Deployment currently fails with: Input required and not supplied: accountId, because CLOUDFLARE_ACCOUNT_ID is not set as a repo secret.

This PR makes the preview-deploy job skip unless secrets.CLOUDFLARE_ACCOUNT_ID is configured, so Actions stops going red by default while keeping the preview path available if we decide to enable it later.