### PR TITLE
CI: properly skip Cloudflare preview when secrets missing

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -15,7 +15,10 @@ jobs:
   deploy-preview:
     # This workflow is optional. If CLOUDFLARE_ACCOUNT_ID is not configured,
     # skip the preview deploy instead of failing the entire Actions run history.
-    if: ${{ github.event.workflow_run.conclusion == 'success' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+          && (secrets.CLOUDFLARE_ACCOUNT_ID || '') != ''
+          && (secrets.CLOUDFLARE_API_TOKEN || '') != '' }}
     runs-on: ubuntu-latest
     name: Deploy Preview to Cloudflare Pages
     steps:


### PR DESCRIPTION
The previous guard still allowed the job to run because a missing secret can evaluate in a way that makes `!= ""` truthy.

This updates the condition to coerce missing secrets to "" via `(secrets.X || "")`, so the preview deploy job is skipped unless both `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are configured.