### PR TITLE
CI: fix deploy-preview workflow file error

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -15,10 +15,7 @@ jobs:
   deploy-preview:
     # This workflow is optional. If CLOUDFLARE_ACCOUNT_ID is not configured,
     # skip the preview deploy instead of failing the entire Actions run history.
-    if: >-
-      ${{ github.event.workflow_run.conclusion == 'success'
-          && (secrets.CLOUDFLARE_ACCOUNT_ID || '') != ''
-          && (secrets.CLOUDFLARE_API_TOKEN || '') != '' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (secrets.CLOUDFLARE_ACCOUNT_ID || '') != '' && (secrets.CLOUDFLARE_API_TOKEN || '') != '' }}
     runs-on: ubuntu-latest
     name: Deploy Preview to Cloudflare Pages
     steps:


### PR DESCRIPTION
The deploy-preview workflow started failing instantly (0s) with a workflow-file issue after introducing a multiline `if: >-` guard.

This rewrites the guard as a single-line expression so the workflow parses cleanly, and it still skips the Cloudflare Pages preview deploy unless both CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are configured.