### PR TITLE
CI: skip Cloudflare preview deploy when secrets are unset

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -15,11 +15,25 @@ jobs:
   deploy-preview:
     # This workflow is optional. If CLOUDFLARE_ACCOUNT_ID is not configured,
     # skip the preview deploy instead of failing the entire Actions run history.
-    if: ${{ github.event.workflow_run.conclusion == 'success' && (secrets.CLOUDFLARE_ACCOUNT_ID || '') != '' && (secrets.CLOUDFLARE_API_TOKEN || '') != '' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Deploy Preview to Cloudflare Pages
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
+      - name: Check Cloudflare preview config
+        id: cf-config
+        run: |
+          if [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] && [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::notice title=Preview deploy skipped::Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN repo secrets to enable Cloudflare Pages preview deployments."
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+
       - name: Download build artifact
+        if: ${{ steps.cf-config.outputs.enabled == 'true' }}
         uses: actions/download-artifact@v7
         id: preview-build-artifact
         with:
@@ -29,10 +43,11 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy to Cloudflare Pages
+        if: ${{ steps.cf-config.outputs.enabled == 'true' }}
         uses: AdrianGonz97/refined-cf-pages-action@v1
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: quartz
           deploymentName: Branch Preview


### PR DESCRIPTION
Fixes the recurring Actions failure: Upload Preview Deployment fails with "Input required and not supplied: accountId".

Root cause: we cannot reference the `secrets` context in a job-level `if:` (GitHub flags it as an invalid workflow file). This PR moves the check into a step that sets an output, and gates the artifact download + Cloudflare Pages deploy steps on that output.

Result: when CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN are not configured, the workflow succeeds and emits a notice instead of failing.