### PR TITLE
Fix practice resolve failing for 120+ genes

### DIFF
--- a/workers/index.js
+++ b/workers/index.js
@@ -38,7 +38,9 @@ const DAILY_BOOTSTRAP_CACHE_TTL = 86400 // 24 hours
 const GENEGUESSR_HOST = "geneguessr.brinedew.bio"
 
 const PRACTICE_RESOLVE_MAX_INPUTS = 10000
-const PRACTICE_RESOLVE_SQL_CHUNK = 400
+// Cloudflare D1 enforces a relatively small limit on bound parameters per query.
+// Keep this low enough to avoid `too many SQL variables`-style failures when users paste 100+ symbols.
+const PRACTICE_RESOLVE_SQL_CHUNK = 100
 
 function buildGeneguessrSubdomainRobotsTxt() {
   return `# robots.txt for ${GENEGUESSR_HOST}


### PR DESCRIPTION
Repro: Paste the full GeneAge table (https://genomics.senescence.info/genes/allgenes.php) into Practice → Validate. The worker returns 500 once the request includes ~120+ symbols.

Cause: `/api/game/practice/resolve` was querying D1 with an `IN (...)` clause containing too many bound parameters at once (chunk size 400). Cloudflare D1 has a lower parameter limit than we assumed.

Fix: reduce `PRACTICE_RESOLVE_SQL_CHUNK` to 100 so larger gene lists are split across multiple queries and resolve stays stable.