### PR TITLE
Fix practice input overflow

### DIFF
--- a/quartz/static/geneguessr/styles.css
+++ b/quartz/static/geneguessr/styles.css
@@ -619,7 +619,11 @@
 }
 
 .pg-practice-textarea {
+  box-sizing: border-box;
   width: 100%;
+  max-width: 100%;
+  display: block;
+  margin: 0;
   resize: vertical;
   min-height: 200px;
   padding: 0.75rem 0.85rem;


### PR DESCRIPTION
The Practice overlay textarea could overflow the card on some layouts because its padding/border were not included in width calculations. This adds ox-sizing: border-box + max-width: 100% to keep the right edge aligned with the rest of the card.