### PR TITLE
Fix Russel -> Russell typo in 'What is an agent'

### DIFF
--- a/content/posts/What is an agent.md
+++ b/content/posts/What is an agent.md
@@ -8,9 +8,9 @@ draft: true
 # What is an agent
 
 The literature on philosophy, cybernetics and AI is littered with debates on what does it mean to call something an agent. They are all very interesting, but for all practical purposes there's a simple pragmatic concept that is worth adopting.
-### Russel-Norvig agents
+### Russell & Norvig agents
 
-The canonical AI textbook *Artificial Intelligence: A Modern Approach* by Russel and Norvig gives a simple practical definition of agents:
+The canonical AI textbook *Artificial Intelligence: A Modern Approach* by Russell and Norvig gives a simple practical definition of agents:
 > "An agent is anything that can be viewed as perceiving its environment through **sensors** and acting upon that environment through **actuators**."
 
 Note how the wording *"viewed as"* shifts focus away from metaphysics of action, and towards the researcher's own interpretation of reality. As we learned, "all models are wrong, but some are useful".


### PR DESCRIPTION
**Test PR to demonstrate the review workflow.**

This is a one-character typo fix on two lines of \content/posts/What is an agent.md\:
- Line 11: \Russel-Norvig agents\ -> \Russell & Norvig agents\
- Line 13: \Russel and Norvig\ -> \Russell and Norvig\

**How to review:** click the \Files changed\ tab to see the diff. Green lines = additions, red lines = removals. Click \Review changes\ (top right) to approve, request changes, or comment.

If you like this workflow, the same pattern works for any content edit I do going forward. If you don't like it, close the PR and the branch is discarded without affecting \main\.