### PR TITLE
Align direct-provider contract test with last-used behavior

### DIFF
--- a/workers/iconoplasm.request-picker-contract.test.js
+++ b/workers/iconoplasm.request-picker-contract.test.js
@@ -391,8 +391,13 @@ test("direct generation result uses edit-modal geometry instead of a handmade si
   )
   assert.match(
     app,
-    /providerSelect\.value = options\.length \? options\[0\]\.value : ""/,
-    "direct generation should default to the first compound provider_id:model option whenever providers exist",
+    /var selectedValue = lastUsedValue \|\| \(options\.length \? options\[0\]\.value : ""\)/,
+    "direct generation should restore the last compound provider_id:model option and otherwise use the first available option",
+  )
+  assert.match(
+    app,
+    /if \(\s*selectedValue\s*&&\s*!options\.some\(function \(opt\) \{\s*return opt\.value === selectedValue\s*\}\)\s*\) \{\s*selectedValue = options\.length \? options\[0\]\.value : ""/,
+    "a removed last-used provider should fall back to the first currently available compound option",
   )
   assert.match(
     css,


### PR DESCRIPTION
The product now restores the last-used compound provider:model and falls back to the first available option when that provider disappears. The old source-contract test still required the first option unconditionally. Targeted contract suite passes 7/7.