### PR TITLE
Add durable Iconoplasm request fulfillment notifications

### DIFF
--- a/migrations-iconoplasm/0047_request_fulfillment_notifications.sql
+++ b/migrations-iconoplasm/0047_request_fulfillment_notifications.sql
@@ -1,0 +1,100 @@
+-- Durable requester inbox + Discord delivery outbox for generation fulfillment.
+--
+-- Chesterton fence: notification creation belongs to the database transition,
+-- not to one particular API caller. The workstation, admin UI, and any future
+-- fulfillment path all update icono_generation_requests; this trigger makes the
+-- inbox row part of the same D1 transaction as open -> fulfilled.
+--
+-- Deliberately no historical backfill. The first Discord rollout is restricted
+-- to a single Brinedew test account, and old fulfillments must not surprise users.
+
+CREATE TABLE IF NOT EXISTS icono_request_notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  notification_key TEXT NOT NULL UNIQUE,
+  request_id INTEGER NOT NULL UNIQUE,
+  requester_user_id TEXT NOT NULL,
+  gene_symbol TEXT NOT NULL,
+  request_mode TEXT NOT NULL DEFAULT 'random'
+    CHECK (request_mode IN ('random', 'specific')),
+  requested_vision_id TEXT NOT NULL DEFAULT '',
+  requested_emulsion_label TEXT NOT NULL DEFAULT '',
+  fulfilled_asset_sha256 TEXT NOT NULL DEFAULT '',
+  fulfilled_vision_id TEXT NOT NULL DEFAULT '',
+  kind TEXT NOT NULL DEFAULT 'request_fulfilled'
+    CHECK (kind IN ('request_fulfilled')),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  read_at TEXT,
+  discord_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (discord_status IN (
+      'pending',
+      'sending',
+      'retry',
+      'sent',
+      'suppressed_not_test_recipient',
+      'failed',
+      'unknown'
+    )),
+  discord_attempt_count INTEGER NOT NULL DEFAULT 0,
+  discord_last_attempt_at TEXT,
+  discord_sent_at TEXT,
+  discord_channel_id TEXT NOT NULL DEFAULT '',
+  discord_message_id TEXT NOT NULL DEFAULT '',
+  discord_error TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_icono_request_notifications_user_created
+  ON icono_request_notifications (requester_user_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_icono_request_notifications_user_unread
+  ON icono_request_notifications (requester_user_id, read_at, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_icono_request_notifications_delivery
+  ON icono_request_notifications (discord_status, discord_attempt_count, created_at ASC, id ASC);
+
+CREATE TRIGGER IF NOT EXISTS trg_icono_generation_request_fulfilled_notification
+AFTER UPDATE OF status ON icono_generation_requests
+WHEN OLD.status <> 'fulfilled' AND NEW.status = 'fulfilled'
+BEGIN
+  INSERT OR IGNORE INTO icono_request_notifications (
+    notification_key,
+    request_id,
+    requester_user_id,
+    gene_symbol,
+    request_mode,
+    requested_vision_id,
+    requested_emulsion_label,
+    fulfilled_asset_sha256,
+    fulfilled_vision_id
+  ) VALUES (
+    'request_fulfilled:' || NEW.id || ':' || COALESCE(NEW.fulfilled_asset_sha256, ''),
+    NEW.id,
+    NEW.requester_user_id,
+    NEW.gene_symbol,
+    NEW.request_mode,
+    NEW.requested_vision_id,
+    CASE
+      WHEN NEW.request_mode = 'random' THEN 'Random default'
+      ELSE COALESCE(
+        NULLIF((
+          SELECT emulsion_id
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF((
+          SELECT artist_tag
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF((
+          SELECT artist_name
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF(NEW.requested_vision_id, ''),
+        'Specific emulsion'
+      )
+    END,
+    COALESCE(NEW.fulfilled_asset_sha256, ''),
+    COALESCE(NEW.fulfilled_vision_id, '')
+  );
+END;

--- a/quartz/static/custom.css
+++ b/quartz/static/custom.css
@@ -495,6 +495,239 @@ article p {
   text-align: right;
 }
 
+.icono-request-inbox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  container-type: inline-size;
+}
+
+.icono-request-inbox__head,
+.icono-request-inbox__summary,
+.icono-request-inbox__line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.icono-request-inbox__head {
+  font-family: "IBM Plex Mono", "Monaspace Xenon Web", monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.icono-request-inbox__unread {
+  padding: 0.12rem 0.42rem;
+  background: var(--dark);
+  color: var(--light);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+
+.icono-request-inbox__quiet,
+.icono-request-inbox__loading {
+  color: var(--secondary);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.icono-request-inbox__summary {
+  padding-bottom: 0.45rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--ui-border) 72%, transparent);
+  color: var(--secondary);
+  font-size: 0.7rem;
+}
+
+.icono-request-inbox__summary button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--dark);
+  font: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--dark) 28%, transparent);
+  text-underline-offset: 0.18em;
+  cursor: pointer;
+}
+
+.icono-request-inbox__summary button:hover,
+.icono-request-inbox__summary button:focus-visible {
+  color: var(--accent);
+  text-decoration-color: currentColor;
+}
+
+.icono-request-inbox__item {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: center;
+  min-height: 56px;
+  padding: 0.38rem 0;
+  color: var(--dark);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--ui-border) 58%, transparent);
+  transition:
+    background-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.icono-request-inbox__item:hover,
+.icono-request-inbox__item:focus-visible {
+  background: color-mix(in srgb, var(--light) 88%, var(--accent) 12%);
+  transform: translateX(3px);
+  outline: none;
+}
+
+.icono-request-inbox__item--unread {
+  background: color-mix(in srgb, var(--light) 82%, #d6b45e 18%);
+}
+
+.icono-request-inbox__item img,
+.icono-request-inbox__photo-placeholder {
+  display: block;
+  width: 44px;
+  height: 56px;
+  object-fit: cover;
+  background: color-mix(in srgb, var(--ui-bg) 82%, var(--dark) 18%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dark) 18%, transparent);
+}
+
+.icono-request-inbox__copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.08rem;
+}
+
+.icono-request-inbox__line strong {
+  font-family: "League Spartan", sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.025em;
+}
+
+.icono-request-inbox__line em {
+  color: var(--secondary);
+  font-family: "IBM Plex Mono", "Monaspace Xenon Web", monospace;
+  font-size: 0.58rem;
+  font-style: normal;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.icono-request-inbox__item--unread .icono-request-inbox__line em {
+  color: var(--dark);
+  font-weight: 700;
+}
+
+.icono-request-inbox__emulsion,
+.icono-request-inbox__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.icono-request-inbox__emulsion {
+  font-size: 0.72rem;
+  font-weight: 620;
+}
+
+.icono-request-inbox__copy small {
+  color: var(--secondary);
+  font-size: 0.64rem;
+}
+
+.icono-request-inbox__item--queued {
+  grid-template-columns: 14px minmax(0, 1fr);
+  min-height: 42px;
+}
+
+.icono-request-inbox__queue-mark {
+  width: 8px;
+  height: 28px;
+  background: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--secondary) 65%, transparent) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.icono-request-inbox__empty {
+  padding: 0.75rem 0;
+  color: var(--secondary);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.icono-request-inbox__empty strong {
+  display: block;
+  margin-bottom: 0.12rem;
+  color: var(--dark);
+}
+
+.icono-request-ready-notice {
+  position: fixed;
+  z-index: 10000;
+  right: clamp(1rem, 3vw, 2.5rem);
+  bottom: clamp(1rem, 3vw, 2.5rem);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 0.8rem 1rem;
+  background: color-mix(in srgb, var(--light) 94%, #d6b45e 6%);
+  color: var(--dark);
+  border: 1px solid color-mix(in srgb, var(--dark) 24%, transparent);
+  box-shadow: 0 18px 55px color-mix(in srgb, var(--dark) 18%, transparent);
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.icono-request-ready-notice--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.icono-request-ready-notice__stamp {
+  padding: 0.2rem 0.42rem;
+  background: var(--dark);
+  color: var(--light);
+  font-family: "IBM Plex Mono", "Monaspace Xenon Web", monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.icono-request-ready-notice strong,
+.icono-request-ready-notice small {
+  display: block;
+}
+
+.icono-request-ready-notice small {
+  margin-top: 0.12rem;
+  color: var(--secondary);
+  font-size: 0.72rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icono-request-inbox__item,
+  .icono-request-ready-notice {
+    transition: none;
+  }
+}
+
 .draft-warning-banner__content {
   min-width: 0;
 }

--- a/quartz/static/iconoplasm/app.js
+++ b/quartz/static/iconoplasm/app.js
@@ -12,6 +12,7 @@ import {
   ICONOPLASM_DISCOVERY_DEFAULT_ORDER,
   ICONOPLASM_GALLERY_DEFAULT_ORDER,
 } from "./home-orders.js"
+import { createRequestInbox } from "./request-inbox.js"
 import {
   buildLoginUrl,
   buildSharedUserPanelMarkup,
@@ -419,6 +420,17 @@ var initialSharedSettingsPromise = syncSharedIconoplasmSettings().catch(function
     d.textContent = s
     return d.innerHTML
   }
+
+  var requestInbox = createRequestInbox({
+    fetchJSON: fetchJSON,
+    getCurrentUser: function () {
+      return currentUser
+    },
+    renderSidebar: function () {
+      renderIconoplasmSidebar()
+    },
+    escapeHtml: esc,
+  })
 
   function normalizedSymbol(symbol) {
     return String(symbol || "")
@@ -2130,6 +2142,14 @@ var initialSharedSettingsPromise = syncSharedIconoplasmSettings().catch(function
         }),
       },
     ]
+    var requestInboxMarkup = requestInbox.panelMarkup()
+    if (requestInboxMarkup) {
+      panels.push({
+        id: "icono-request-inbox-panel",
+        className: "brd-sidebar-panel--request-inbox",
+        markup: requestInboxMarkup,
+      })
+    }
     if (iconoSidebarMarkup) {
       panels.push({
         id: "icono-sidebar-panel",
@@ -2146,6 +2166,7 @@ var initialSharedSettingsPromise = syncSharedIconoplasmSettings().catch(function
         void updateSharedUserState(user)
       },
     })
+    requestInbox.wire(stack)
     renderHomeInstallCta()
   }
 
@@ -2169,6 +2190,12 @@ var initialSharedSettingsPromise = syncSharedIconoplasmSettings().catch(function
     hasResolvedAuthState = true
     if (previousHadUser !== !!currentUser) {
       invalidateImageEditProviders()
+    }
+    if (currentUser) {
+      requestInbox.start()
+    } else {
+      requestInbox.stop()
+      requestInbox.reset()
     }
     renderIconoplasmSidebar()
     if (getRoute().page === "home") {
@@ -6596,6 +6623,7 @@ var initialSharedSettingsPromise = syncSharedIconoplasmSettings().catch(function
           .then(function () {
             delete geneRequestSummaryCache[symbol]
             setStatus("Queued for free generation.", "success")
+            void requestInbox.refresh()
             return fetchGeneRequestSummary(symbol, { forceFresh: true }).then(function (state) {
               wireAuthenticatedRequestForm(state)
               return state

--- a/quartz/static/iconoplasm/request-inbox.js
+++ b/quartz/static/iconoplasm/request-inbox.js
@@ -1,0 +1,267 @@
+// Server-backed request inbox for Iconoplasm.
+//
+// This component owns its refresh lifecycle, durable read acknowledgements,
+// rendering, and interaction wiring. app.js supplies only the shared API,
+// current-user, sidebar-render, and escaping boundaries.
+
+export function createRequestInbox({ fetchJSON, getCurrentUser, renderSidebar, escapeHtml }) {
+  var state = {
+    loaded: false,
+    loading: false,
+    unread_count: 0,
+    open_count: 0,
+    open_requests: [],
+    notifications: [],
+    last_seen_notification_id: 0,
+  }
+  var refreshTimer = 0
+  var lifecycleWired = false
+
+  function ageLabel(createdAt) {
+    if (!createdAt) return "recently"
+    var timestamp = String(createdAt).trim().replace(" ", "T")
+    if (!/(?:Z|[+-]\d\d:\d\d)$/i.test(timestamp)) timestamp += "Z"
+    var parsed = new Date(timestamp).getTime()
+    if (!Number.isFinite(parsed)) return "recently"
+    var seconds = Math.max(0, Math.floor((Date.now() - parsed) / 1000))
+    if (seconds < 60) return "just now"
+    if (seconds < 3600) return Math.floor(seconds / 60) + "m ago"
+    if (seconds < 86400) return Math.floor(seconds / 3600) + "h ago"
+    if (seconds < 86400 * 30) return Math.floor(seconds / 86400) + "d ago"
+    return Math.floor(seconds / (86400 * 30)) + "mo ago"
+  }
+
+  function showFulfilledNotice(notification) {
+    if (!notification || !notification.gene_symbol) return
+    var existing = document.getElementById("icono-request-ready-notice")
+    if (existing) existing.remove()
+    var notice = document.createElement("a")
+    notice.id = "icono-request-ready-notice"
+    notice.className = "icono-request-ready-notice"
+    notice.href = notification.gene_url || "/"
+    notice.setAttribute("role", "status")
+    notice.setAttribute("aria-live", "polite")
+    notice.innerHTML =
+      '<span class="icono-request-ready-notice__stamp">Ready</span>' +
+      "<span><strong>" +
+      escapeHtml(notification.gene_symbol) +
+      "</strong><small>" +
+      escapeHtml(notification.requested_emulsion_label || "Your requested blot") +
+      "</small></span>"
+    document.body.appendChild(notice)
+    window.setTimeout(function () {
+      notice.classList.add("icono-request-ready-notice--visible")
+    }, 20)
+    window.setTimeout(function () {
+      notice.classList.remove("icono-request-ready-notice--visible")
+      window.setTimeout(function () {
+        if (notice.parentNode) notice.remove()
+      }, 220)
+    }, 9000)
+  }
+
+  function reset() {
+    state.loaded = false
+    state.loading = false
+    state.unread_count = 0
+    state.open_count = 0
+    state.open_requests = []
+    state.notifications = []
+    state.last_seen_notification_id = 0
+  }
+
+  function refresh(options) {
+    var opts = options || {}
+    if (!getCurrentUser() || state.loading) return Promise.resolve(null)
+    state.loading = true
+    if (!state.loaded) renderSidebar()
+    return fetchJSON("/api/iconoplasm/notifications?limit=25&fresh=" + Date.now(), {
+      credentials: "include",
+      cache: "no-store",
+    })
+      .then(function (payload) {
+        if (!payload || !payload.ok || !payload.authenticated) return null
+        var notifications = Array.isArray(payload.notifications) ? payload.notifications : []
+        var previousHighWater = state.last_seen_notification_id
+        var newestUnread = notifications.find(function (item) {
+          return item && item.unread && Number(item.id || 0) > previousHighWater
+        })
+        state.loaded = true
+        state.unread_count = Math.max(0, Number(payload.unread_count || 0) || 0)
+        state.open_count = Math.max(0, Number(payload.open_count || 0) || 0)
+        state.open_requests = Array.isArray(payload.open_requests) ? payload.open_requests : []
+        state.notifications = notifications
+        state.last_seen_notification_id = notifications.reduce(function (highest, item) {
+          return Math.max(highest, Number((item && item.id) || 0) || 0)
+        }, previousHighWater)
+        renderSidebar()
+        if (opts.announce && previousHighWater > 0 && newestUnread) {
+          showFulfilledNotice(newestUnread)
+        }
+        return payload
+      })
+      .catch(function () {
+        return null
+      })
+      .finally(function () {
+        state.loading = false
+      })
+  }
+
+  function markRead(notificationIds, markAll) {
+    return fetchJSON("/api/iconoplasm/notifications/read", {
+      method: "POST",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({
+        notification_ids: Array.isArray(notificationIds) ? notificationIds : [],
+        all: markAll === true,
+      }),
+    }).then(function () {
+      return refresh()
+    })
+  }
+
+  function stop() {
+    if (refreshTimer) window.clearInterval(refreshTimer)
+    refreshTimer = 0
+  }
+
+  function start() {
+    stop()
+    if (!getCurrentUser()) return
+    void refresh()
+    refreshTimer = window.setInterval(function () {
+      if (document.visibilityState === "visible") void refresh({ announce: true })
+    }, 60000)
+    if (lifecycleWired) return
+    lifecycleWired = true
+    window.addEventListener("focus", function () {
+      if (getCurrentUser()) void refresh({ announce: true })
+    })
+    document.addEventListener("visibilitychange", function () {
+      if (getCurrentUser() && document.visibilityState === "visible") {
+        void refresh({ announce: true })
+      }
+    })
+  }
+
+  function panelMarkup() {
+    if (!getCurrentUser()) return ""
+    if (state.loading && !state.loaded) {
+      return (
+        '<div class="icono-request-inbox" aria-busy="true">' +
+        '<div class="icono-request-inbox__head"><span>Request inbox</span>' +
+        '<span class="icono-request-inbox__loading">Checking…</span></div></div>'
+      )
+    }
+    var notifications = Array.isArray(state.notifications) ? state.notifications.slice(0, 8) : []
+    var openRequests = Array.isArray(state.open_requests) ? state.open_requests.slice(0, 4) : []
+    var unread = Math.max(0, Number(state.unread_count || 0) || 0)
+    var openCount = Math.max(0, Number(state.open_count || 0) || 0)
+    var html =
+      '<div class="icono-request-inbox">' +
+      '<div class="icono-request-inbox__head"><span>Request inbox</span>' +
+      (unread
+        ? '<span class="icono-request-inbox__unread" aria-label="' +
+          escapeHtml(String(unread)) +
+          ' unread">' +
+          escapeHtml(String(unread)) +
+          " new</span>"
+        : '<span class="icono-request-inbox__quiet">Up to date</span>') +
+      "</div>" +
+      '<div class="icono-request-inbox__summary">' +
+      escapeHtml(
+        openCount
+          ? openCount + (openCount === 1 ? " request waiting" : " requests waiting")
+          : "Nothing waiting",
+      ) +
+      (unread
+        ? '<button type="button" data-icono-request-inbox-read-all>Mark all read</button>'
+        : "") +
+      "</div>"
+
+    if (!notifications.length && !openRequests.length) {
+      html +=
+        '<div class="icono-request-inbox__empty"><strong>No requests yet.</strong>' +
+        "Ask for a new blot on any gene page; its result will appear here.</div>"
+    }
+
+    for (var i = 0; i < notifications.length; i++) {
+      var item = notifications[i] || {}
+      html +=
+        '<a class="icono-request-inbox__item' +
+        (item.unread ? " icono-request-inbox__item--unread" : "") +
+        '" href="' +
+        escapeHtml(item.gene_url || "/") +
+        '" data-icono-request-notification-id="' +
+        escapeHtml(String(item.id || "")) +
+        '">' +
+        (item.image_url
+          ? '<img src="' +
+            escapeHtml(item.image_url) +
+            '" alt="" loading="lazy" decoding="async" width="44" height="56">'
+          : '<span class="icono-request-inbox__photo-placeholder" aria-hidden="true"></span>') +
+        '<span class="icono-request-inbox__copy"><span class="icono-request-inbox__line"><strong>' +
+        escapeHtml(item.gene_symbol || "Gene") +
+        "</strong><em>ready</em></span>" +
+        '<span class="icono-request-inbox__emulsion">' +
+        escapeHtml(item.requested_emulsion_label || "Requested blot") +
+        "</span><small>Fulfilled " +
+        escapeHtml(ageLabel(item.created_at)) +
+        "</small></span></a>"
+    }
+
+    for (var j = 0; j < openRequests.length; j++) {
+      var queued = openRequests[j] || {}
+      html +=
+        '<a class="icono-request-inbox__item icono-request-inbox__item--queued" href="' +
+        escapeHtml(queued.gene_url || "/") +
+        '" data-icono-nav><span class="icono-request-inbox__queue-mark" aria-hidden="true"></span>' +
+        '<span class="icono-request-inbox__copy"><span class="icono-request-inbox__line"><strong>' +
+        escapeHtml(queued.gene_symbol || "Gene") +
+        "</strong><em>queued</em></span>" +
+        '<span class="icono-request-inbox__emulsion">' +
+        escapeHtml(queued.requested_emulsion_label || "Random default") +
+        "</span><small>Requested " +
+        escapeHtml(ageLabel(queued.created_at)) +
+        "</small></span></a>"
+    }
+    return html + "</div>"
+  }
+
+  function wire(stack) {
+    if (!stack) return
+    var readAll = stack.querySelector("[data-icono-request-inbox-read-all]")
+    if (readAll) {
+      readAll.addEventListener("click", function () {
+        readAll.disabled = true
+        void markRead([], true).finally(function () {
+          readAll.disabled = false
+        })
+      })
+    }
+    var links = stack.querySelectorAll("[data-icono-request-notification-id]")
+    for (var i = 0; i < links.length; i++) {
+      ;(function (link) {
+        link.addEventListener("click", function (event) {
+          var id = Number.parseInt(
+            link.getAttribute("data-icono-request-notification-id") || "0",
+            10,
+          )
+          if (!id) return
+          event.preventDefault()
+          var href = link.getAttribute("href") || "/"
+          void markRead([id], false)
+            .catch(function () {})
+            .finally(function () {
+              window.location.assign(href)
+            })
+        })
+      })(links[i])
+    }
+  }
+
+  return { panelMarkup, refresh, reset, start, stop, wire }
+}

--- a/workers/iconoplasm-request-notifications.js
+++ b/workers/iconoplasm-request-notifications.js
@@ -1,0 +1,322 @@
+// Durable request-fulfillment inbox and best-effort Discord delivery.
+//
+// The D1 trigger owns notification creation. This module owns only reads,
+// acknowledgement, and delivery so the already-large Iconoplasm runtime does
+// not absorb another state machine.
+
+// B-640 rollout fence: only Vladimir's immutable Discord user ID may receive
+// fulfillment DMs during the test period. Never replace this with a username.
+export const ICONOPLASM_FULFILLMENT_DM_TEST_RECIPIENT_ID = "1289482311557058641"
+
+const DISCORD_API_BASE = "https://discord.com/api/v10"
+const DISCORD_MAX_ATTEMPTS = 4
+
+function boundedText(value, maxLength) {
+  const text = String(value || "").trim()
+  return text ? text.slice(0, maxLength) : ""
+}
+
+function positiveInteger(value) {
+  return Math.max(0, Number.parseInt(String(value || "0"), 10) || 0)
+}
+
+function userId(value) {
+  return boundedText(value, 255)
+}
+
+function geneSymbol(value) {
+  const symbol = boundedText(value, 64).toUpperCase()
+  return /^[A-Z0-9][A-Z0-9-]{0,63}$/.test(symbol) ? symbol : ""
+}
+
+function assetSha(value) {
+  const sha = boundedText(value, 64).toLowerCase()
+  return /^[a-f0-9]{64}$/.test(sha) ? sha : ""
+}
+
+function mapNotification(row, portraitUrlForAsset) {
+  const id = positiveInteger(row?.id)
+  const requestId = positiveInteger(row?.request_id)
+  const symbol = geneSymbol(row?.gene_symbol)
+  const sha = assetSha(row?.fulfilled_asset_sha256)
+  const readAt = boundedText(row?.read_at, 64)
+  return {
+    id,
+    notification_key: boundedText(row?.notification_key, 255),
+    request_id: requestId,
+    kind: "request_fulfilled",
+    gene_symbol: symbol,
+    requested_emulsion_label:
+      boundedText(row?.requested_emulsion_label, 255) ||
+      (row?.request_mode === "specific" ? "Specific emulsion" : "Random default"),
+    fulfilled_asset_sha256: sha,
+    fulfilled_vision_id: boundedText(row?.fulfilled_vision_id, 255),
+    created_at: boundedText(row?.created_at, 64),
+    read_at: readAt,
+    unread: !readAt,
+    gene_url: symbol ? `/gene/${encodeURIComponent(symbol)}` : "/",
+    image_url: sha && portraitUrlForAsset ? portraitUrlForAsset(sha) : "",
+    discord_status: boundedText(row?.discord_status, 64) || "pending",
+  }
+}
+
+export async function readRequestNotificationInbox(
+  env,
+  { requesterUserId, limit = 25, openRequests = [], portraitUrlForAsset } = {},
+) {
+  if (!env?.ICONOPLASM_DB) {
+    return { ok: false, status: 500, error: "ICONOPLASM_DB binding missing" }
+  }
+  const requesterId = userId(requesterUserId)
+  if (!requesterId) return { ok: false, status: 401, error: "Authentication required" }
+  const safeLimit = Math.max(1, Math.min(50, positiveInteger(limit) || 25))
+  const [unreadRow, rowsResponse] = await Promise.all([
+    env.ICONOPLASM_DB.prepare(
+      `SELECT COUNT(*) AS unread_count
+       FROM icono_request_notifications
+       WHERE requester_user_id = ?
+         AND read_at IS NULL`,
+    )
+      .bind(requesterId)
+      .first(),
+    env.ICONOPLASM_DB.prepare(
+      `SELECT n.*
+       FROM icono_request_notifications n
+       WHERE n.requester_user_id = ?
+       ORDER BY n.created_at DESC, n.id DESC
+       LIMIT ?`,
+    )
+      .bind(requesterId, safeLimit)
+      .all(),
+  ])
+  const pending = Array.isArray(openRequests) ? openRequests : []
+  return {
+    ok: true,
+    authenticated: true,
+    unread_count: positiveInteger(unreadRow?.unread_count),
+    open_count: pending.length,
+    open_requests: pending.map((row) => {
+      const symbol = geneSymbol(row?.gene_symbol)
+      return {
+        request_id: positiveInteger(row?.id),
+        gene_symbol: symbol,
+        requested_emulsion_label:
+          boundedText(row?.requested_emulsion_label, 255) || "Random default",
+        created_at: boundedText(row?.created_at, 64),
+        gene_url: symbol ? `/gene/${encodeURIComponent(symbol)}` : "/",
+      }
+    }),
+    notifications: (Array.isArray(rowsResponse?.results) ? rowsResponse.results : []).map((row) =>
+      mapNotification(row, portraitUrlForAsset),
+    ),
+  }
+}
+
+export async function markRequestNotificationsRead(
+  env,
+  { requesterUserId, notificationIds = [], markAll = false } = {},
+) {
+  if (!env?.ICONOPLASM_DB) {
+    return { ok: false, status: 500, error: "ICONOPLASM_DB binding missing" }
+  }
+  const requesterId = userId(requesterUserId)
+  if (!requesterId) return { ok: false, status: 401, error: "Authentication required" }
+  let response
+  if (markAll) {
+    response = await env.ICONOPLASM_DB.prepare(
+      `UPDATE icono_request_notifications
+       SET read_at = COALESCE(read_at, CURRENT_TIMESTAMP)
+       WHERE requester_user_id = ?
+         AND read_at IS NULL`,
+    )
+      .bind(requesterId)
+      .run()
+  } else {
+    const ids = Array.from(
+      new Set(
+        (Array.isArray(notificationIds) ? notificationIds : [])
+          .map(positiveInteger)
+          .filter(Boolean),
+      ),
+    ).slice(0, 50)
+    if (!ids.length) return { ok: false, status: 400, error: "No notification IDs supplied" }
+    const placeholders = ids.map(() => "?").join(",")
+    response = await env.ICONOPLASM_DB.prepare(
+      `UPDATE icono_request_notifications
+       SET read_at = COALESCE(read_at, CURRENT_TIMESTAMP)
+       WHERE requester_user_id = ?
+         AND id IN (${placeholders})`,
+    )
+      .bind(requesterId, ...ids)
+      .run()
+  }
+  return { ok: true, marked_read: positiveInteger(response?.meta?.changes) }
+}
+
+function discordMessage(row) {
+  const symbol = geneSymbol(row?.gene_symbol) || "your gene"
+  const emulsion =
+    boundedText(row?.requested_emulsion_label, 255) ||
+    (row?.request_mode === "specific" ? "your requested emulsion" : "a random emulsion")
+  return [
+    `Your Iconoplasm request is ready: **${symbol}**`,
+    `Emulsion: ${emulsion}`,
+    `https://iconoplasm.brinedew.bio/gene/${encodeURIComponent(symbol)}`,
+  ].join("\n")
+}
+
+async function setDiscordState(env, notificationId, status, fields = {}) {
+  await env.ICONOPLASM_DB.prepare(
+    `UPDATE icono_request_notifications
+     SET discord_status = ?,
+         discord_sent_at = CASE WHEN ? = 'sent' THEN CURRENT_TIMESTAMP ELSE discord_sent_at END,
+         discord_channel_id = ?,
+         discord_message_id = ?,
+         discord_error = ?
+     WHERE id = ?`,
+  )
+    .bind(
+      status,
+      status,
+      boundedText(fields.channelId, 255),
+      boundedText(fields.messageId, 255),
+      boundedText(fields.error, 1000),
+      notificationId,
+    )
+    .run()
+}
+
+export async function deliverPendingRequestFulfillmentNotifications(
+  env,
+  { requestIds = [], limit = 20 } = {},
+) {
+  if (!env?.ICONOPLASM_DB) {
+    return { ok: false, delivered: 0, error: "ICONOPLASM_DB binding missing" }
+  }
+  const safeLimit = Math.max(1, Math.min(50, positiveInteger(limit) || 20))
+  const ids = Array.from(
+    new Set((Array.isArray(requestIds) ? requestIds : []).map(positiveInteger).filter(Boolean)),
+  ).slice(0, 50)
+  const where = ["n.discord_status IN ('pending', 'retry')", "n.discord_attempt_count < ?"]
+  const params = [DISCORD_MAX_ATTEMPTS]
+  if (ids.length) {
+    where.push(`n.request_id IN (${ids.map(() => "?").join(",")})`)
+    params.push(...ids)
+  }
+  const rowsResponse = await env.ICONOPLASM_DB.prepare(
+    `SELECT n.*
+     FROM icono_request_notifications n
+     WHERE ${where.join(" AND ")}
+     ORDER BY n.created_at ASC, n.id ASC
+     LIMIT ?`,
+  )
+    .bind(...params, safeLimit)
+    .all()
+
+  const result = { ok: true, considered: 0, delivered: 0, suppressed: 0, failed: 0, unknown: 0 }
+  for (const row of Array.isArray(rowsResponse?.results) ? rowsResponse.results : []) {
+    const notificationId = positiveInteger(row?.id)
+    const requesterId = userId(row?.requester_user_id)
+    if (!notificationId || !requesterId) continue
+    result.considered += 1
+
+    // This check must remain before token lookup or fetch. Non-test users have
+    // no code path that can touch Discord during the rollout.
+    if (requesterId !== ICONOPLASM_FULFILLMENT_DM_TEST_RECIPIENT_ID) {
+      await setDiscordState(env, notificationId, "suppressed_not_test_recipient", {
+        error: "Discord test delivery is restricted to the Brinedew account.",
+      })
+      result.suppressed += 1
+      continue
+    }
+
+    const claim = await env.ICONOPLASM_DB.prepare(
+      `UPDATE icono_request_notifications
+       SET discord_status = 'sending',
+           discord_attempt_count = discord_attempt_count + 1,
+           discord_last_attempt_at = CURRENT_TIMESTAMP,
+           discord_error = ''
+       WHERE id = ?
+         AND discord_status IN ('pending', 'retry')`,
+    )
+      .bind(notificationId)
+      .run()
+    if (Number(claim?.meta?.changes || 0) !== 1) continue
+
+    const botToken = String(env?.DISCORD_BOT_TOKEN || "").trim()
+    if (!botToken) {
+      await setDiscordState(env, notificationId, "retry", {
+        error: "DISCORD_BOT_TOKEN is not configured.",
+      })
+      result.failed += 1
+      continue
+    }
+
+    let channelId = ""
+    try {
+      const response = await fetch(`${DISCORD_API_BASE}/users/@me/channels`, {
+        method: "POST",
+        headers: { Authorization: `Bot ${botToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ recipient_id: requesterId }),
+      })
+      const payload = await response.json().catch(() => ({}))
+      channelId = boundedText(payload?.id, 255)
+      if (!response.ok || !channelId) {
+        await setDiscordState(env, notificationId, "retry", {
+          error: `Discord DM channel failed (${response.status}): ${boundedText(payload?.message, 500)}`,
+        })
+        result.failed += 1
+        continue
+      }
+    } catch (error) {
+      // Opening a channel has no user-visible side effect, so retry is safe.
+      await setDiscordState(env, notificationId, "retry", {
+        error: `Discord DM channel network failure: ${boundedText(error?.message || error || "unknown", 500)}`,
+      })
+      result.failed += 1
+      continue
+    }
+
+    try {
+      const response = await fetch(
+        `${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bot ${botToken}`, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            content: discordMessage(row),
+            nonce: `icono-fulfillment-${notificationId}`,
+            enforce_nonce: true,
+            allowed_mentions: { parse: [] },
+          }),
+        },
+      )
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        const status =
+          response.status === 429 ? "retry" : response.status >= 500 ? "unknown" : "failed"
+        await setDiscordState(env, notificationId, status, {
+          channelId,
+          error: `Discord message failed (${response.status}): ${boundedText(payload?.message, 500)}`,
+        })
+        if (status === "unknown") result.unknown += 1
+        else result.failed += 1
+        continue
+      }
+      await setDiscordState(env, notificationId, "sent", {
+        channelId,
+        messageId: boundedText(payload?.id, 255),
+      })
+      result.delivered += 1
+    } catch (error) {
+      // A failed response read after POST is ambiguous. Do not retry and risk
+      // a duplicate DM; the durable website inbox remains authoritative.
+      await setDiscordState(env, notificationId, "unknown", {
+        channelId,
+        error: `Discord message delivery outcome unknown: ${boundedText(error?.message || error || "unknown", 500)}`,
+      })
+      result.unknown += 1
+    }
+  }
+  return result
+}

--- a/workers/iconoplasm-stateful-runtime-inside-the-only-allowed-internal-worker-do-not-duplicate.js
+++ b/workers/iconoplasm-stateful-runtime-inside-the-only-allowed-internal-worker-do-not-duplicate.js
@@ -6,6 +6,11 @@ import { ICONOPLASM_ADMIN_HTML } from "./iconoplasm-admin-html.js"
 import { ICONOPLASM_OBSERVABILITY_SNAPSHOT } from "./generated/iconoplasm-observability-snapshot.js"
 import { ICONOPLASM_CLAN_CATALOG } from "./generated/iconoplasm-clan-catalog.js"
 import { renderIconoplasmArtistStylesHtml } from "./iconoplasm-artist-styles-html.js"
+import {
+  deliverPendingRequestFulfillmentNotifications,
+  markRequestNotificationsRead as markRequestNotificationsReadForUser,
+  readRequestNotificationInbox,
+} from "./iconoplasm-request-notifications.js"
 import { ICONOPLASM_WIKI_PAGEVIEWS } from "./iconoplasm-wiki-pageviews.js"
 import { normalizeIconoplasmHomeOrder } from "../quartz/static/iconoplasm/home-orders.js"
 import "../shared/iconoplasm-card/shared-card-runtime.js"
@@ -1292,6 +1297,8 @@ function iconoplasmBudgetRouteFamilyFromPath(path) {
   if (/^\/api\/iconoplasm\/genes\/[^/]+\/comments$/.test(path)) return "gene_comments"
   if (path === "/api/iconoplasm/requests") return "gene_request_submit"
   if (path === "/api/iconoplasm/requests/options") return "gene_request_options"
+  if (path === "/api/iconoplasm/notifications") return "request_notifications"
+  if (path === "/api/iconoplasm/notifications/read") return "request_notifications_read"
   if (/^\/api\/iconoplasm\/requests\/gene\/[^/]+\/summary$/.test(path))
     return "gene_request_summary"
   if (/^\/api\/iconoplasm\/requests\/gene\/[^/]+$/.test(path)) return "gene_request_state_gone"
@@ -1399,6 +1406,8 @@ function iconoplasmBudgetClassFromRouteFamily(routeFamily) {
   if (family === "gene_comments") return "first_party_write"
   if (family.startsWith("discoveries_")) return "first_party_write"
   if (family.startsWith("gene_request_")) return "first_party_request"
+  if (family === "request_notifications") return "first_party_read"
+  if (family === "request_notifications_read") return "first_party_write"
   if (family.startsWith("image_edit_")) return "first_party_write"
   if (family === "user_emulsion") return "first_party_write"
   if (family.startsWith("candidate_generation_")) return "first_party_write"
@@ -3672,6 +3681,47 @@ function mapGenerationRequestRow(row) {
   }
 }
 
+async function requestNotificationInboxPayload(env, request, { limit = 25 } = {}) {
+  const sessionUser = await iconoplasmSessionUser(request, env)
+  const requesterUserId = normalizeUserId(sessionUser?.user_id || "")
+  if (!requesterUserId || isGuestUserId(requesterUserId)) {
+    return {
+      ok: true,
+      authenticated: false,
+      unread_count: 0,
+      open_count: 0,
+      open_requests: [],
+      notifications: [],
+    }
+  }
+  const openRequests = await listOpenGenerationRequests(env, {
+    limit: 10,
+    requesterUserId,
+  })
+  const base = portraitBase(new URL("https://iconoplasm.brinedew.bio/"), env)
+  return readRequestNotificationInbox(env, {
+    requesterUserId,
+    limit,
+    openRequests,
+    portraitUrlForAsset(asset) {
+      return adminPortraitUrl(base, asset, "thumb")
+    },
+  })
+}
+
+async function markRequestNotificationsRead(
+  env,
+  request,
+  { notificationIds = [], markAll = false } = {},
+) {
+  const sessionUser = await iconoplasmSessionUser(request, env)
+  const requesterUserId = normalizeUserId(sessionUser?.user_id || "")
+  return markRequestNotificationsReadForUser(env, {
+    requesterUserId: isGuestUserId(requesterUserId) ? "" : requesterUserId,
+    notificationIds,
+    markAll,
+  })
+}
 function mapGeneDiscoveryRow(row) {
   const weightKg = Number(row?.weight_kg)
   const ageYears = Number(row?.age_years)
@@ -10056,6 +10106,9 @@ function isIconoplasmPathHandledInsideTheOnlyAllowedStatefulWorker(path, method 
   if (/^\/api\/iconoplasm\/requests\/gene\/[^/]+$/.test(path))
     return requestMethod === "GET" || requestMethod === "HEAD"
   if (path === "/api/iconoplasm/requests") return requestMethod === "POST"
+  if (path === "/api/iconoplasm/notifications")
+    return requestMethod === "GET" || requestMethod === "HEAD"
+  if (path === "/api/iconoplasm/notifications/read") return requestMethod === "POST"
   if (path === "/api/iconoplasm/admin/requests/open")
     return requestMethod === "GET" || requestMethod === "HEAD"
   if (path === "/api/iconoplasm/admin/requests/fulfill") return requestMethod === "POST"
@@ -26577,6 +26630,35 @@ export async function handleIconoplasmApiRequestInsideTheOnlyAllowedStatefulWork
       )
     }
 
+    if (path === "/api/iconoplasm/notifications" && request.method === "GET") {
+      const payload = await requestNotificationInboxPayload(env, request, {
+        limit: url.searchParams.get("limit") || "25",
+      })
+      return done(
+        payload.ok ? "request_notifications" : "request_notifications_500",
+        json(payload, payload.status || (payload.ok ? 200 : 500), { "Cache-Control": "no-store" }),
+      )
+    }
+
+    if (path === "/api/iconoplasm/notifications/read" && request.method === "POST") {
+      let p = {}
+      try {
+        p = await request.json()
+      } catch {
+        return done("request_notifications_read_400", json({ error: "Invalid JSON" }, 400))
+      }
+      const payload = await markRequestNotificationsRead(env, request, {
+        notificationIds: p?.notification_ids,
+        markAll: p?.all === true,
+      })
+      return done(
+        payload.ok
+          ? "request_notifications_read"
+          : `request_notifications_read_${payload.status || 500}`,
+        json(payload, payload.status || (payload.ok ? 200 : 500), { "Cache-Control": "no-store" }),
+      )
+    }
+
     if (path === "/api/iconoplasm/admin/requests/open" && request.method === "GET") {
       if (!(await isIconoplasmAdmin(request, env)))
         return done("admin_requests_open_403", json({ error: "Unauthorized" }, 403))
@@ -26624,6 +26706,18 @@ export async function handleIconoplasmApiRequestInsideTheOnlyAllowedStatefulWork
         items: Array.isArray(p?.items) ? p.items : [],
         resolvedBy: await actor(request, env),
       })
+      if (result.request_ids?.length) {
+        const delivery = deliverPendingRequestFulfillmentNotifications(env, {
+          requestIds: result.request_ids,
+        }).catch((error) => {
+          console.error(
+            "Iconoplasm fulfillment notification delivery failed:",
+            sanitizeText(error?.message || error || "unknown error", 500),
+          )
+        })
+        if (ctx?.waitUntil) ctx.waitUntil(delivery)
+        else await delivery
+      }
       return done("admin_requests_fulfill", json(result, 200, { "Cache-Control": "no-store" }))
     }
 

--- a/workers/iconoplasm.request-notifications.test.js
+++ b/workers/iconoplasm.request-notifications.test.js
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+import { handleIconoplasmRequestInsideTheOnlyAllowedInternalStatefulWorkerDoNotDuplicate } from "./iconoplasm-stateful-runtime-inside-the-only-allowed-internal-worker-do-not-duplicate.js"
+import { deliverPendingRequestFulfillmentNotifications } from "./iconoplasm-request-notifications.js"
+
+const BRINEDEW_USER_ID = "1289482311557058641"
+
+class NotificationStatement {
+  constructor(db, sql) {
+    this.db = db
+    this.sql = String(sql || "")
+    this.args = []
+  }
+
+  bind(...args) {
+    this.args = args
+    return this
+  }
+
+  async first() {
+    if (this.sql.includes("COUNT(*) AS unread_count")) {
+      return { unread_count: this.db.notifications.filter((row) => !row.read_at).length }
+    }
+    return null
+  }
+
+  async all() {
+    if (
+      this.sql.includes("FROM icono_request_notifications n") &&
+      this.sql.includes("discord_status IN")
+    ) {
+      return {
+        results: this.db.notifications.filter((row) =>
+          ["pending", "retry"].includes(row.discord_status),
+        ),
+      }
+    }
+    if (this.sql.includes("FROM icono_request_notifications n")) {
+      return { results: this.db.notifications }
+    }
+    if (this.sql.includes("FROM icono_generation_requests gr")) {
+      return { results: this.db.openRequests }
+    }
+    return { results: [] }
+  }
+
+  async run() {
+    if (this.sql.includes("SET read_at = COALESCE")) {
+      const userId = String(this.args[0] || "")
+      const ids = this.args.slice(1).map(Number)
+      let changes = 0
+      for (const row of this.db.notifications) {
+        if (row.requester_user_id !== userId || row.read_at) continue
+        if (ids.length && !ids.includes(Number(row.id))) continue
+        row.read_at = "2026-07-16 14:00:00"
+        changes += 1
+      }
+      return { meta: { changes } }
+    }
+    if (this.sql.includes("discord_attempt_count = discord_attempt_count + 1")) {
+      const row = this.db.notifications.find((item) => Number(item.id) === Number(this.args[0]))
+      if (!row || !["pending", "retry"].includes(row.discord_status))
+        return { meta: { changes: 0 } }
+      row.discord_status = "sending"
+      row.discord_attempt_count = Number(row.discord_attempt_count || 0) + 1
+      return { meta: { changes: 1 } }
+    }
+    if (this.sql.includes("SET discord_status = ?")) {
+      const id = Number(this.args[5])
+      const row = this.db.notifications.find((item) => Number(item.id) === id)
+      if (!row) return { meta: { changes: 0 } }
+      row.discord_status = String(this.args[0] || "")
+      row.discord_channel_id = String(this.args[2] || "")
+      row.discord_message_id = String(this.args[3] || "")
+      row.discord_error = String(this.args[4] || "")
+      return { meta: { changes: 1 } }
+    }
+    throw new Error(`Unexpected notification SQL: ${this.sql}`)
+  }
+}
+
+class NotificationDb {
+  constructor(notifications = [], openRequests = []) {
+    this.notifications = notifications
+    this.openRequests = openRequests
+  }
+
+  prepare(sql) {
+    return new NotificationStatement(this, sql)
+  }
+}
+
+function buildSessionBinding(userId = BRINEDEW_USER_ID) {
+  return {
+    idFromName(name) {
+      return name
+    },
+    get() {
+      return {
+        async fetch() {
+          return Response.json({ user_id: userId, username: "brinedew" })
+        },
+      }
+    },
+  }
+}
+
+function notificationRow(overrides = {}) {
+  return {
+    id: 7,
+    notification_key: "request_fulfilled:42:" + "a".repeat(64),
+    request_id: 42,
+    requester_user_id: BRINEDEW_USER_ID,
+    gene_symbol: "INS",
+    fulfilled_asset_sha256: "a".repeat(64),
+    fulfilled_vision_id: "anima-v1-4527",
+    request_mode: "specific",
+    requested_vision_id: "anima-v1-4527",
+    requested_emulsion_id: "A1-4527",
+    requested_emulsion_label: "A1-4527",
+    requested_artist_tag: "anima",
+    requested_artist_name: "Anima",
+    requested_workflow_id: "A1-",
+    requested_prompt_version: "4",
+    requested_variant_slot: "527",
+    fulfillment_note: "fulfilled by workstation website sync",
+    created_at: "2026-07-16 13:45:00",
+    read_at: null,
+    discord_status: "pending",
+    discord_attempt_count: 0,
+    ...overrides,
+  }
+}
+
+test("notification migration creates inbox rows atomically and never backfills users", () => {
+  const migration = readFileSync(
+    new URL("../migrations-iconoplasm/0047_request_fulfillment_notifications.sql", import.meta.url),
+    "utf8",
+  )
+
+  assert.match(migration, /AFTER UPDATE OF status ON icono_generation_requests/)
+  assert.match(migration, /OLD\.status <> 'fulfilled' AND NEW\.status = 'fulfilled'/)
+  assert.match(migration, /INSERT OR IGNORE INTO icono_request_notifications/)
+  assert.match(migration, /request_id INTEGER NOT NULL UNIQUE/)
+  assert.doesNotMatch(migration, /INSERT[\s\S]+SELECT[\s\S]+FROM icono_generation_requests/i)
+})
+
+test("authenticated inbox returns exact fulfillment context and durable unread count", async () => {
+  const db = new NotificationDb(
+    [notificationRow()],
+    [
+      {
+        id: 51,
+        gene_symbol: "TP53",
+        requester_user_id: BRINEDEW_USER_ID,
+        request_mode: "random",
+        requested_vision_id: "",
+        request_kind: "new_candidate",
+        status: "open",
+        created_at: "2026-07-16 13:50:00",
+      },
+    ],
+  )
+  const response =
+    await handleIconoplasmRequestInsideTheOnlyAllowedInternalStatefulWorkerDoNotDuplicate(
+      new Request("https://iconoplasm.brinedew.bio/api/iconoplasm/notifications", {
+        headers: { Cookie: "session=test" },
+      }),
+      { ICONOPLASM_DB: db, GAME_SESSIONS: buildSessionBinding() },
+      { waitUntil() {} },
+    )
+  const payload = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(payload.authenticated, true)
+  assert.equal(payload.unread_count, 1)
+  assert.equal(payload.open_count, 1)
+  assert.equal(payload.notifications[0].request_id, 42)
+  assert.equal(payload.notifications[0].gene_symbol, "INS")
+  assert.equal(payload.notifications[0].requested_emulsion_label, "A1-4527")
+  assert.match(payload.notifications[0].image_url, /a{64}\/thumb\.webp$/)
+})
+
+test("read state is written only inside the authenticated requester's inbox", async () => {
+  const own = notificationRow({ id: 7 })
+  const anotherUser = notificationRow({
+    id: 8,
+    request_id: 43,
+    requester_user_id: "757634039292362843",
+  })
+  const db = new NotificationDb([own, anotherUser])
+  const response =
+    await handleIconoplasmRequestInsideTheOnlyAllowedInternalStatefulWorkerDoNotDuplicate(
+      new Request("https://iconoplasm.brinedew.bio/api/iconoplasm/notifications/read", {
+        method: "POST",
+        headers: { Cookie: "session=test", "Content-Type": "application/json" },
+        body: JSON.stringify({ notification_ids: [7, 8] }),
+      }),
+      { ICONOPLASM_DB: db, GAME_SESSIONS: buildSessionBinding() },
+      { waitUntil() {} },
+    )
+  const payload = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(payload.marked_read, 1)
+  assert.ok(own.read_at)
+  assert.equal(anotherUser.read_at, null)
+})
+
+test("non-Brinedew fulfillment is suppressed before any Discord fetch", async () => {
+  const row = notificationRow({ requester_user_id: "757634039292362843" })
+  const db = new NotificationDb([row])
+  const originalFetch = globalThis.fetch
+  let fetchCalls = 0
+  globalThis.fetch = async () => {
+    fetchCalls += 1
+    throw new Error("Discord must not be called")
+  }
+  try {
+    const result = await deliverPendingRequestFulfillmentNotifications(
+      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
+      { requestIds: [42] },
+    )
+    assert.equal(result.suppressed, 1)
+    assert.equal(result.delivered, 0)
+    assert.equal(fetchCalls, 0)
+    assert.equal(row.discord_status, "suppressed_not_test_recipient")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("Brinedew fulfillment sends one nonce-enforced DM and is retry-idempotent", async () => {
+  const row = notificationRow()
+  const db = new NotificationDb([row])
+  const calls = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body || "{}")) })
+    if (String(url).endsWith("/users/@me/channels")) return Response.json({ id: "dm-channel-1" })
+    return Response.json({ id: "discord-message-1" })
+  }
+  try {
+    const first = await deliverPendingRequestFulfillmentNotifications(
+      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
+      { requestIds: [42] },
+    )
+    const second = await deliverPendingRequestFulfillmentNotifications(
+      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
+      { requestIds: [42] },
+    )
+
+    assert.equal(first.delivered, 1)
+    assert.equal(second.considered, 0)
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0].body.recipient_id, BRINEDEW_USER_ID)
+    assert.equal(calls[1].body.nonce, "icono-fulfillment-7")
+    assert.equal(calls[1].body.enforce_nonce, true)
+    assert.deepEqual(calls[1].body.allowed_mentions, { parse: [] })
+    assert.match(calls[1].body.content, /INS/)
+    assert.match(calls[1].body.content, /A1-4527/)
+    assert.equal(row.discord_status, "sent")
+    assert.equal(row.discord_message_id, "discord-message-1")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("an ambiguous Discord message POST is terminal and never retried", async () => {
+  const row = notificationRow()
+  const db = new NotificationDb([row])
+  const originalFetch = globalThis.fetch
+  let fetchCalls = 0
+  globalThis.fetch = async (url) => {
+    fetchCalls += 1
+    if (String(url).endsWith("/users/@me/channels")) return Response.json({ id: "dm-channel-1" })
+    throw new Error("socket closed after upload")
+  }
+  try {
+    const first = await deliverPendingRequestFulfillmentNotifications(
+      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
+      { requestIds: [42] },
+    )
+    const second = await deliverPendingRequestFulfillmentNotifications(
+      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
+      { requestIds: [42] },
+    )
+
+    assert.equal(first.unknown, 1)
+    assert.equal(second.considered, 0)
+    assert.equal(fetchCalls, 2)
+    assert.equal(row.discord_status, "unknown")
+    assert.match(row.discord_error, /outcome unknown/i)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("request inbox UI uses server read state and bounded live refresh", () => {
+  const app = readFileSync(new URL("../quartz/static/iconoplasm/app.js", import.meta.url), "utf8")
+  const inbox = readFileSync(
+    new URL("../quartz/static/iconoplasm/request-inbox.js", import.meta.url),
+    "utf8",
+  )
+  const css = readFileSync(new URL("../quartz/static/custom.css", import.meta.url), "utf8")
+
+  assert.match(app, /import \{ createRequestInbox \} from "\.\/request-inbox\.js"/)
+  assert.match(inbox, /\/api\/iconoplasm\/notifications\?limit=25/)
+  assert.match(inbox, /\/api\/iconoplasm\/notifications\/read/)
+  assert.match(inbox, /refreshTimer = window\.setInterval/)
+  assert.match(inbox, /document\.visibilityState === "visible"/)
+  assert.match(inbox, /data-icono-request-notification-id/)
+  assert.doesNotMatch(inbox, /icono_last_seen_fulfilled/)
+  assert.match(css, /\.icono-request-inbox__item--unread/)
+  assert.match(css, /prefers-reduced-motion: reduce/)
+})
+
+test("notification routes stay explicitly classified by the fail-loud cost fence", () => {
+  const worker = readFileSync(
+    new URL(
+      "./iconoplasm-stateful-runtime-inside-the-only-allowed-internal-worker-do-not-duplicate.js",
+      import.meta.url,
+    ),
+    "utf8",
+  )
+
+  assert.match(worker, /family === "request_notifications"\) return "first_party_read"/)
+  assert.match(worker, /family === "request_notifications_read"\) return "first_party_write"/)
+})

--- a/workers/the-only-allowed-internal-stateful-worker-runtime-do-not-duplicate.js
+++ b/workers/the-only-allowed-internal-stateful-worker-runtime-do-not-duplicate.js
@@ -872,6 +872,7 @@ import {
   IconoplasmSyncGovernor,
   handleIconoplasmQueue,
 } from "./iconoplasm-stateful-runtime-inside-the-only-allowed-internal-worker-do-not-duplicate.js"
+import { deliverPendingRequestFulfillmentNotifications } from "./iconoplasm-request-notifications.js"
 import { handleRequestAtTheOnlyAllowedStatefulWorkerForBenchmarkDoNotDuplicate } from "./benchmark/the-only-allowed-benchmark-stateful-runtime-do-not-duplicate.js"
 
 export { IconoplasmVoteCoordinator }
@@ -2608,8 +2609,26 @@ export default {
     }
 
     if (cronExpr === "*/15 * * * *") {
-      // Cheap gallery-only freshness tick — NOT the heavy maintenance.
-      await runScheduledIconoplasmGalleryRefresh(env, ctx)
+      // These jobs share a clock, not a failure domain. Drain the durable outbox
+      // even when the unrelated gallery refresh fails, while preserving the
+      // gallery job's existing fail-loud behavior.
+      const [galleryRefresh, notificationDelivery] = await Promise.allSettled([
+        runScheduledIconoplasmGalleryRefresh(env, ctx),
+        deliverPendingRequestFulfillmentNotifications(env, { limit: 20 }),
+      ])
+      if (notificationDelivery.status === "fulfilled") {
+        if (notificationDelivery.value.considered) {
+          console.log("[CRON] Iconoplasm fulfillment notifications:", notificationDelivery.value)
+        }
+      } else {
+        console.error(
+          "[CRON] Iconoplasm fulfillment notification delivery failed:",
+          String(
+            notificationDelivery.reason?.message || notificationDelivery.reason || "unknown error",
+          ),
+        )
+      }
+      if (galleryRefresh.status === "rejected") throw galleryRefresh.reason
       return
     }
 


### PR DESCRIPTION
## What changed

- Creates a durable, server-backed request fulfillment inbox in D1.
- Snapshots notification context atomically when a request transitions from open to fulfilled.
- Adds durable per-user read state and a sidebar request history with waiting and ready items.
- Adds best-effort Discord fulfillment delivery with an enforced stable nonce.
- Hard-gates all test DMs to the immutable Discord ID for the `brinedew` account before any Discord network call.
- Suppresses every non-Brinedew delivery during rollout.
- Failure-isolates bounded outbox retries from the unrelated gallery refresh cron.
- Keeps backend and frontend notification state machines in focused modules instead of growing the existing giant files.

## Why

Fulfilled requests were not discoverable by users. The previous local/ephemeral notification work was not deployed and could not survive another device or cleared browser state. Fulfillment also needed a safe Discord acceptance path that cannot contact other users during testing.

## Safety

- No historical backfill.
- Inbox is authoritative; Discord is best-effort.
- Non-Brinedew notifications make zero Discord requests.
- Ambiguous Discord message outcomes are terminal, preventing duplicate retries.
- Notification read writes are scoped to the authenticated requester.
- Exact fulfillment context is stored on the notification row rather than joined from mutable request tables.

## Validation

- `pnpm run check`
- `pnpm test` — 623/623 passing
- `pnpm run build` — 2,903 files emitted
- Fresh local Wrangler D1 migration
- Real D1 trigger probe: exact emulsion snapshot and pending outbox row
- Historical fulfilled insert probe: zero backfilled notifications
