### PR TITLE
Fix Iconoplasm fulfillment DM context and image attachment

### DIFF
--- a/migrations-iconoplasm/0048_request_notification_request_kind.sql
+++ b/migrations-iconoplasm/0048_request_notification_request_kind.sql
@@ -1,0 +1,73 @@
+-- Preserve the user journey that produced a fulfillment notification.
+--
+-- 0047 intentionally snapshotted fulfillment context instead of joining the
+-- mutable request row at read time, but it omitted request_kind. That made the
+-- first Discord copy generic enough to hide the actual free-queue action.
+
+ALTER TABLE icono_request_notifications
+  ADD COLUMN request_kind TEXT NOT NULL DEFAULT 'new_candidate'
+  CHECK (request_kind IN ('new_candidate', 'edit_image'));
+
+-- Existing notification rows predate this column. Backfill metadata only; do
+-- not create or redeliver any historical notification.
+UPDATE icono_request_notifications
+SET request_kind = COALESCE((
+  SELECT gr.request_kind
+  FROM icono_generation_requests gr
+  WHERE gr.id = icono_request_notifications.request_id
+), 'new_candidate');
+
+-- Replace the 0047 trigger so future rows snapshot request_kind atomically with
+-- the rest of the notification. Trigger creation remains at the status
+-- transition boundary; API callers must not grow their own notification path.
+DROP TRIGGER IF EXISTS trg_icono_generation_request_fulfilled_notification;
+
+CREATE TRIGGER trg_icono_generation_request_fulfilled_notification
+AFTER UPDATE OF status ON icono_generation_requests
+WHEN OLD.status <> 'fulfilled' AND NEW.status = 'fulfilled'
+BEGIN
+  INSERT OR IGNORE INTO icono_request_notifications (
+    notification_key,
+    request_id,
+    requester_user_id,
+    gene_symbol,
+    request_kind,
+    request_mode,
+    requested_vision_id,
+    requested_emulsion_label,
+    fulfilled_asset_sha256,
+    fulfilled_vision_id
+  ) VALUES (
+    'request_fulfilled:' || NEW.id || ':' || COALESCE(NEW.fulfilled_asset_sha256, ''),
+    NEW.id,
+    NEW.requester_user_id,
+    NEW.gene_symbol,
+    NEW.request_kind,
+    NEW.request_mode,
+    NEW.requested_vision_id,
+    CASE
+      WHEN NEW.request_mode = 'random' THEN 'Random default'
+      ELSE COALESCE(
+        NULLIF((
+          SELECT emulsion_id
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF((
+          SELECT artist_tag
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF((
+          SELECT artist_name
+          FROM icono_admin_vision_rollup
+          WHERE vision_id = NEW.requested_vision_id
+        ), ''),
+        NULLIF(NEW.requested_vision_id, ''),
+        'Specific emulsion'
+      )
+    END,
+    COALESCE(NEW.fulfilled_asset_sha256, ''),
+    COALESCE(NEW.fulfilled_vision_id, '')
+  );
+END;

--- a/workers/iconoplasm-request-notifications.js
+++ b/workers/iconoplasm-request-notifications.js
@@ -10,6 +10,10 @@ export const ICONOPLASM_FULFILLMENT_DM_TEST_RECIPIENT_ID = "1289482311557058641"
 
 const DISCORD_API_BASE = "https://discord.com/api/v10"
 const DISCORD_MAX_ATTEMPTS = 4
+// Discord's default per-file upload limit is 10 MiB. Portrait full renditions
+// are capped far below that in normal operation, but reject oversized or bogus
+// CDN responses before buffering them into a multipart request.
+const DISCORD_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
 
 function boundedText(value, maxLength) {
   const text = String(value || "").trim()
@@ -34,6 +38,10 @@ function assetSha(value) {
   return /^[a-f0-9]{64}$/.test(sha) ? sha : ""
 }
 
+function requestKind(value) {
+  return boundedText(value, 64) === "edit_image" ? "edit_image" : "new_candidate"
+}
+
 function mapNotification(row, portraitUrlForAsset) {
   const id = positiveInteger(row?.id)
   const requestId = positiveInteger(row?.request_id)
@@ -45,6 +53,7 @@ function mapNotification(row, portraitUrlForAsset) {
     notification_key: boundedText(row?.notification_key, 255),
     request_id: requestId,
     kind: "request_fulfilled",
+    request_kind: requestKind(row?.request_kind),
     gene_symbol: symbol,
     requested_emulsion_label:
       boundedText(row?.requested_emulsion_label, 255) ||
@@ -155,14 +164,179 @@ export async function markRequestNotificationsRead(
 
 function discordMessage(row) {
   const symbol = geneSymbol(row?.gene_symbol) || "your gene"
+  const isEdit = requestKind(row?.request_kind) === "edit_image"
   const emulsion =
-    boundedText(row?.requested_emulsion_label, 255) ||
-    (row?.request_mode === "specific" ? "your requested emulsion" : "a random emulsion")
+    row?.request_mode === "specific"
+      ? boundedText(row?.requested_emulsion_label, 255) || "Your selected emulsion"
+      : "Random selection"
+  const action = isEdit
+    ? `You asked Iconoplasm's free generation queue to edit the **${symbol}** blot.`
+    : `You asked Iconoplasm's free generation queue for a new **${symbol}** candidate blot.`
   return [
-    `Your Iconoplasm request is ready: **${symbol}**`,
-    `Emulsion: ${emulsion}`,
-    `https://iconoplasm.brinedew.bio/gene/${encodeURIComponent(symbol)}`,
+    isEdit
+      ? "**Your free blot-edit request is ready**"
+      : "**Your free candidate request is ready**",
+    action,
+    `Emulsion: **${emulsion}**`,
+    `Review it here: <https://iconoplasm.brinedew.bio/gene/${encodeURIComponent(symbol)}>`,
   ].join("\n")
+}
+
+function portraitCdnBase(env) {
+  return boundedText(
+    env?.ICONOPLASM_EXTERNAL_PORTRAIT_CDN_BASE_URL || env?.ICONOPLASM_PORTRAIT_BASE_URL || "",
+    2000,
+  ).replace(/\/+$/, "")
+}
+
+function fulfilledPortraitUrl(env, row) {
+  const sha = assetSha(row?.fulfilled_asset_sha256)
+  const base = portraitCdnBase(env)
+  if (!sha || !base) return ""
+  return `${base}/portraits/v1/${sha.slice(0, 2)}/${sha}/full.webp`
+}
+
+function fulfilledPortraitRequest(env, row) {
+  const sha = assetSha(row?.fulfilled_asset_sha256)
+  if (!sha) return null
+  const key = `portraits/v1/${sha.slice(0, 2)}/${sha}/full.webp`
+  const storageZone = boundedText(env?.ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_ZONE, 255)
+  const storagePassword = boundedText(env?.ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_PASSWORD, 2000)
+  if (storageZone && storagePassword) {
+    const storageHost =
+      boundedText(env?.ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_HOST, 255) || "storage.bunnycdn.com"
+    return {
+      url: `https://${storageHost}/${encodeURIComponent(storageZone)}/${key}`,
+      headers: { AccessKey: storagePassword, Accept: "image/webp" },
+    }
+  }
+  const publicUrl = fulfilledPortraitUrl(env, row)
+  return publicUrl ? { url: publicUrl, headers: { Accept: "image/webp" } } : null
+}
+
+function hasWebpSignature(bytes) {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < 12) return false
+  return (
+    String.fromCharCode(...bytes.slice(0, 4)) === "RIFF" &&
+    String.fromCharCode(...bytes.slice(8, 12)) === "WEBP"
+  )
+}
+
+async function readBoundedResponseBytes(response, maxBytes) {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    return bytes.byteLength <= maxBytes ? bytes : null
+  }
+
+  const chunks = []
+  let byteLength = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      byteLength += value.byteLength
+      if (byteLength > maxBytes) {
+        await reader.cancel("Discord attachment limit exceeded")
+        return null
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const bytes = new Uint8Array(byteLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+async function loadFulfilledPortraitAttachment(env, row) {
+  const symbol = geneSymbol(row?.gene_symbol) || "gene"
+  const sha = assetSha(row?.fulfilled_asset_sha256)
+  const portraitRequest = fulfilledPortraitRequest(env, row)
+  if (!sha || !portraitRequest) {
+    return {
+      ok: false,
+      retryable: false,
+      error: "Fulfilled portrait attachment is missing a valid asset SHA or CDN base URL.",
+    }
+  }
+
+  let response
+  try {
+    response = await fetch(portraitRequest.url, { headers: portraitRequest.headers })
+  } catch (error) {
+    return {
+      ok: false,
+      retryable: true,
+      error: `Fulfilled portrait download failed: ${boundedText(error?.message || error || "unknown", 500)}`,
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      retryable: response.status === 429 || response.status >= 500,
+      error: `Fulfilled portrait download failed (${response.status}).`,
+    }
+  }
+
+  const contentType = boundedText(response.headers.get("Content-Type"), 255)
+    .split(";", 1)[0]
+    .toLowerCase()
+  const declaredBytes = Number.parseInt(response.headers.get("Content-Length") || "0", 10) || 0
+  if (contentType !== "image/webp" && contentType !== "application/octet-stream") {
+    return {
+      ok: false,
+      retryable: false,
+      error: `Fulfilled portrait has unexpected content type: ${contentType || "missing"}.`,
+    }
+  }
+  if (declaredBytes > DISCORD_ATTACHMENT_MAX_BYTES) {
+    return {
+      ok: false,
+      retryable: false,
+      error: `Fulfilled portrait exceeds Discord's ${DISCORD_ATTACHMENT_MAX_BYTES}-byte upload limit.`,
+    }
+  }
+
+  let bytes
+  try {
+    bytes = await readBoundedResponseBytes(response, DISCORD_ATTACHMENT_MAX_BYTES)
+  } catch (error) {
+    return {
+      ok: false,
+      retryable: true,
+      error: `Fulfilled portrait download interrupted: ${boundedText(error?.message || error || "unknown", 500)}`,
+    }
+  }
+  if (!bytes) {
+    return {
+      ok: false,
+      retryable: false,
+      error: `Fulfilled portrait exceeds Discord's ${DISCORD_ATTACHMENT_MAX_BYTES}-byte upload limit.`,
+    }
+  }
+  if (!hasWebpSignature(bytes)) {
+    return {
+      ok: false,
+      retryable: false,
+      error: "Fulfilled portrait is not a valid WebP image.",
+    }
+  }
+  const filename = `iconoplasm-${symbol.toLowerCase()}-${sha.slice(0, 12)}.webp`
+  const requestLabel =
+    requestKind(row?.request_kind) === "edit_image" ? "blot edit" : "candidate blot"
+  return {
+    ok: true,
+    filename,
+    description: `${symbol} ${requestLabel} from Iconoplasm's free generation queue`,
+    blob: new Blob([bytes], { type: "image/webp" }),
+  }
 }
 
 async function setDiscordState(env, notificationId, status, fields = {}) {
@@ -252,6 +426,15 @@ export async function deliverPendingRequestFulfillmentNotifications(
       continue
     }
 
+    const attachment = await loadFulfilledPortraitAttachment(env, row)
+    if (!attachment.ok) {
+      await setDiscordState(env, notificationId, attachment.retryable ? "retry" : "failed", {
+        error: attachment.error,
+      })
+      result.failed += 1
+      continue
+    }
+
     let channelId = ""
     try {
       const response = await fetch(`${DISCORD_API_BASE}/users/@me/channels`, {
@@ -278,17 +461,29 @@ export async function deliverPendingRequestFulfillmentNotifications(
     }
 
     try {
+      const messagePayload = {
+        content: discordMessage(row),
+        nonce: `icono-fulfillment-${notificationId}`,
+        enforce_nonce: true,
+        allowed_mentions: { parse: [] },
+        attachments: [
+          {
+            id: 0,
+            filename: attachment.filename,
+            description: attachment.description,
+          },
+        ],
+      }
+      const form = new FormData()
+      form.append("payload_json", JSON.stringify(messagePayload))
+      form.append("files[0]", attachment.blob, attachment.filename)
       const response = await fetch(
         `${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}/messages`,
         {
           method: "POST",
-          headers: { Authorization: `Bot ${botToken}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            content: discordMessage(row),
-            nonce: `icono-fulfillment-${notificationId}`,
-            enforce_nonce: true,
-            allowed_mentions: { parse: [] },
-          }),
+          // Do not set Content-Type: fetch must add the multipart boundary.
+          headers: { Authorization: `Bot ${botToken}` },
+          body: form,
         },
       )
       const payload = await response.json().catch(() => ({}))

--- a/workers/iconoplasm.request-notifications.test.js
+++ b/workers/iconoplasm.request-notifications.test.js
@@ -114,6 +114,7 @@ function notificationRow(overrides = {}) {
     request_id: 42,
     requester_user_id: BRINEDEW_USER_ID,
     gene_symbol: "INS",
+    request_kind: "new_candidate",
     fulfilled_asset_sha256: "a".repeat(64),
     fulfilled_vision_id: "anima-v1-4527",
     request_mode: "specific",
@@ -134,6 +135,39 @@ function notificationRow(overrides = {}) {
   }
 }
 
+function validWebpResponse() {
+  const bytes = new Uint8Array([
+    0x52,
+    0x49,
+    0x46,
+    0x46, // RIFF
+    0x08,
+    0x00,
+    0x00,
+    0x00,
+    0x57,
+    0x45,
+    0x42,
+    0x50, // WEBP
+    0x56,
+    0x50,
+    0x38,
+    0x20,
+  ])
+  return new Response(bytes, { headers: { "Content-Type": "image/webp" } })
+}
+
+function deliveryEnv(db) {
+  return {
+    ICONOPLASM_DB: db,
+    DISCORD_BOT_TOKEN: "test-token",
+    ICONOPLASM_PORTRAIT_BASE_URL: "https://iconoplasmportraits.b-cdn.net",
+    ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_HOST: "storage.bunnycdn.com",
+    ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_ZONE: "iconoplasm-portraits",
+    ICONOPLASM_EXTERNAL_PORTRAIT_STORAGE_PASSWORD: "test-storage-access-key",
+  }
+}
+
 test("notification migration creates inbox rows atomically and never backfills users", () => {
   const migration = readFileSync(
     new URL("../migrations-iconoplasm/0047_request_fulfillment_notifications.sql", import.meta.url),
@@ -145,6 +179,18 @@ test("notification migration creates inbox rows atomically and never backfills u
   assert.match(migration, /INSERT OR IGNORE INTO icono_request_notifications/)
   assert.match(migration, /request_id INTEGER NOT NULL UNIQUE/)
   assert.doesNotMatch(migration, /INSERT[\s\S]+SELECT[\s\S]+FROM icono_generation_requests/i)
+
+  const requestKindMigration = readFileSync(
+    new URL("../migrations-iconoplasm/0048_request_notification_request_kind.sql", import.meta.url),
+    "utf8",
+  )
+  assert.match(requestKindMigration, /ADD COLUMN request_kind/)
+  assert.match(requestKindMigration, /DROP TRIGGER IF EXISTS/)
+  assert.match(requestKindMigration, /NEW\.request_kind/)
+  assert.doesNotMatch(
+    requestKindMigration,
+    /INSERT[\s\S]+SELECT[\s\S]+FROM icono_generation_requests/i,
+  )
 })
 
 test("authenticated inbox returns exact fulfillment context and durable unread count", async () => {
@@ -238,31 +284,88 @@ test("Brinedew fulfillment sends one nonce-enforced DM and is retry-idempotent",
   const calls = []
   const originalFetch = globalThis.fetch
   globalThis.fetch = async (url, init) => {
-    calls.push({ url: String(url), body: JSON.parse(String(init?.body || "{}")) })
-    if (String(url).endsWith("/users/@me/channels")) return Response.json({ id: "dm-channel-1" })
+    const call = { url: String(url), init }
+    calls.push(call)
+    if (call.url.includes("storage.bunnycdn.com")) return validWebpResponse()
+    if (call.url.endsWith("/users/@me/channels")) {
+      call.json = JSON.parse(String(init?.body || "{}"))
+      return Response.json({ id: "dm-channel-1" })
+    }
+    call.form = init?.body
+    call.json = JSON.parse(String(call.form.get("payload_json") || "{}"))
+    call.file = call.form.get("files[0]")
     return Response.json({ id: "discord-message-1" })
   }
   try {
-    const first = await deliverPendingRequestFulfillmentNotifications(
-      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
-      { requestIds: [42] },
-    )
-    const second = await deliverPendingRequestFulfillmentNotifications(
-      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
-      { requestIds: [42] },
-    )
+    const first = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
+    const second = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
 
     assert.equal(first.delivered, 1)
     assert.equal(second.considered, 0)
-    assert.equal(calls.length, 2)
-    assert.equal(calls[0].body.recipient_id, BRINEDEW_USER_ID)
-    assert.equal(calls[1].body.nonce, "icono-fulfillment-7")
-    assert.equal(calls[1].body.enforce_nonce, true)
-    assert.deepEqual(calls[1].body.allowed_mentions, { parse: [] })
-    assert.match(calls[1].body.content, /INS/)
-    assert.match(calls[1].body.content, /A1-4527/)
+    assert.equal(calls.length, 3)
+    assert.match(
+      calls[0].url,
+      new RegExp(`/iconoplasm-portraits/portraits/v1/aa/${"a".repeat(64)}/full\\.webp$`),
+    )
+    assert.equal(calls[0].init.headers.AccessKey, "test-storage-access-key")
+    assert.equal(calls[1].json.recipient_id, BRINEDEW_USER_ID)
+    assert.ok(calls[2].form instanceof FormData)
+    assert.equal(calls[2].init.headers["Content-Type"], undefined)
+    assert.equal(calls[2].json.nonce, "icono-fulfillment-7")
+    assert.equal(calls[2].json.enforce_nonce, true)
+    assert.deepEqual(calls[2].json.allowed_mentions, { parse: [] })
+    assert.match(calls[2].json.content, /free candidate request/i)
+    assert.match(calls[2].json.content, /free generation queue/i)
+    assert.match(calls[2].json.content, /new \*\*INS\*\* candidate blot/)
+    assert.match(calls[2].json.content, /Emulsion: \*\*A1-4527\*\*/)
+    assert.match(calls[2].json.content, /<https:\/\/iconoplasm\.brinedew\.bio\/gene\/INS>/)
+    assert.doesNotMatch(calls[2].json.content, /\nhttps:\/\//)
+    assert.deepEqual(calls[2].json.attachments, [
+      {
+        id: 0,
+        filename: `iconoplasm-ins-${"a".repeat(12)}.webp`,
+        description: "INS candidate blot from Iconoplasm's free generation queue",
+      },
+    ])
+    assert.equal(calls[2].file.name, `iconoplasm-ins-${"a".repeat(12)}.webp`)
+    assert.equal(calls[2].file.type, "image/webp")
+    assert.ok(calls[2].file.size > 0)
     assert.equal(row.discord_status, "sent")
     assert.equal(row.discord_message_id, "discord-message-1")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("free blot-edit fulfillment copy preserves its distinct user journey", async () => {
+  const row = notificationRow({ request_kind: "edit_image" })
+  const db = new NotificationDb([row])
+  const originalFetch = globalThis.fetch
+  let messagePayload
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes("storage.bunnycdn.com")) return validWebpResponse()
+    if (String(url).endsWith("/users/@me/channels")) {
+      return Response.json({ id: "dm-channel-1" })
+    }
+    messagePayload = JSON.parse(String(init?.body?.get("payload_json") || "{}"))
+    return Response.json({ id: "discord-message-1" })
+  }
+  try {
+    const result = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
+
+    assert.equal(result.delivered, 1)
+    assert.match(messagePayload.content, /free blot-edit request/i)
+    assert.match(messagePayload.content, /free generation queue to edit the \*\*INS\*\* blot/i)
+    assert.equal(
+      messagePayload.attachments[0].description,
+      "INS blot edit from Iconoplasm's free generation queue",
+    )
   } finally {
     globalThis.fetch = originalFetch
   }
@@ -275,24 +378,76 @@ test("an ambiguous Discord message POST is terminal and never retried", async ()
   let fetchCalls = 0
   globalThis.fetch = async (url) => {
     fetchCalls += 1
+    if (String(url).includes("storage.bunnycdn.com")) return validWebpResponse()
     if (String(url).endsWith("/users/@me/channels")) return Response.json({ id: "dm-channel-1" })
     throw new Error("socket closed after upload")
   }
   try {
-    const first = await deliverPendingRequestFulfillmentNotifications(
-      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
-      { requestIds: [42] },
-    )
-    const second = await deliverPendingRequestFulfillmentNotifications(
-      { ICONOPLASM_DB: db, DISCORD_BOT_TOKEN: "test-token" },
-      { requestIds: [42] },
-    )
+    const first = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
+    const second = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
 
     assert.equal(first.unknown, 1)
     assert.equal(second.considered, 0)
-    assert.equal(fetchCalls, 2)
+    assert.equal(fetchCalls, 3)
     assert.equal(row.discord_status, "unknown")
     assert.match(row.discord_error, /outcome unknown/i)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a missing fulfilled image fails visibly before Discord receives a message", async () => {
+  const row = notificationRow()
+  const db = new NotificationDb([row])
+  const originalFetch = globalThis.fetch
+  const urls = []
+  globalThis.fetch = async (url) => {
+    urls.push(String(url))
+    return new Response("missing", { status: 404, headers: { "Content-Type": "text/plain" } })
+  }
+  try {
+    const result = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
+
+    assert.equal(result.delivered, 0)
+    assert.equal(result.failed, 1)
+    assert.equal(urls.length, 1)
+    assert.match(urls[0], /storage\.bunnycdn\.com/)
+    assert.doesNotMatch(urls[0], /discord\.com/)
+    assert.equal(row.discord_status, "failed")
+    assert.match(row.discord_error, /portrait download failed \(404\)/i)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("an interrupted fulfilled image download returns the outbox to retry", async () => {
+  const row = notificationRow()
+  const db = new NotificationDb([row])
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    new Response(
+      new ReadableStream({
+        pull(controller) {
+          controller.error(new Error("storage stream reset"))
+        },
+      }),
+      { headers: { "Content-Type": "image/webp" } },
+    )
+  try {
+    const result = await deliverPendingRequestFulfillmentNotifications(deliveryEnv(db), {
+      requestIds: [42],
+    })
+
+    assert.equal(result.delivered, 0)
+    assert.equal(result.failed, 1)
+    assert.equal(row.discord_status, "retry")
+    assert.match(row.discord_error, /download interrupted.*storage stream reset/i)
   } finally {
     globalThis.fetch = originalFetch
   }


### PR DESCRIPTION
## What changed

- snapshot the original request kind into the durable fulfillment notification at the database transition boundary
- identify free candidate-generation and blot-edit requests explicitly in the Discord copy
- wrap the gene URL in angle brackets so Discord does not create a redundant embed
- load the exact fulfilled `full.webp` from authenticated Bunny storage and send it as a multipart Discord attachment
- fail visibly without sending an image-less DM when the fulfilled asset is missing or invalid
- retain the immutable `brinedew`-only Discord recipient gate and nonce-based delivery idempotency

## Root cause

The original notification schema omitted `request_kind`, so delivery could not explain the user action that produced the message. The Discord sender also posted JSON-only content with a bare URL and never loaded the fulfilled asset.

## Validation

- local D1 migration apply and trigger probe (including direct-fulfilled no-notification and open-to-fulfilled request-kind snapshot)
- 625 repository tests passing
- TypeScript and Prettier check passing
- production build passing
- production secret inventory confirms authenticated Bunny storage access is configured

Linear: https://linear.app/brinedew/issue/B-640/durable-request-fulfillment-inbox-brinedew-only-discord-dm-test-gate